### PR TITLE
make Ember.LayoutState#parentView property volatile

### DIFF
--- a/packages/ember-layout/lib/layout_state.js
+++ b/packages/ember-layout/lib/layout_state.js
@@ -97,5 +97,5 @@ Ember.LayoutState = Ember.State.extend({
       state = state.get('parentState');
     }
     return state && state.get('view');
-  }).property()
+  }).property().volatile()
 });


### PR DESCRIPTION
Properties are cached by default when `Ember.CP_DEFAULT_CACHEABLE` is true, which will be the default in Ember 1.0

This causes the `parentView` property to never change, causing `content` to be set on the incorrect view on subsequent changes leading to blank sections.

This change just makes the `parentView` property volatile.
